### PR TITLE
Modificación de unidades de equivalencia

### DIFF
--- a/ConversionUnIf.html
+++ b/ConversionUnIf.html
@@ -102,10 +102,10 @@
                             <label class="input-group-text" for="inputGroupSelect01" style="width: 40%;">UNIDAD DE DATO</label>
                             <select name="b1" class="form-select" id="UdatosE">
                               <option selected>Seleccione...</option>
-                              <option value="1099511627776">Byte</option>
-                              <option value="1073741824">Kilobyte</option>
-                              <option value="1048576">Megabyte</option>
-                              <option value="1024">Gigabyte</option>
+                              <option value="1000000000000">Byte</option>
+                              <option value="1000000000">Kilobyte</option>
+                              <option value="1000000">Megabyte</option>
+                              <option value="1000">Gigabyte</option>
                               <option value="1">Terabyte</option>
                             </select>
                           </div>
@@ -119,10 +119,10 @@
                             <label class="input-group-text" for="inputGroupSelect01" style="width: 40%;">UNIDAD DE DATO</label>
                             <select class="form-select" id="UdatosS">
                                 <option selected>Seleccione...</option>
-                                <option value="1099511627776">Byte</option>
-                                <option value="1073741824">Kilobyte</option>
-                                <option value="1048576">Megabyte</option>
-                                <option value="1024">Gigabyte</option>
+                                <option value="1000000000000">Byte</option>
+                                <option value="1000000000">Kilobyte</option>
+                                <option value="1000000">Megabyte</option>
+                                <option value="1000">Gigabyte</option>
                                 <option value="1">Terabyte</option>
                             </select>
                           </div>


### PR DESCRIPTION
Se realiza cambio en unidades de equivalencia como lo solicita la guía y se da en el ejemplo: 5000 kilobyte es igual a 5 Megabyte.